### PR TITLE
Add HTTP::Request as prereq

### DIFF
--- a/META.yml
+++ b/META.yml
@@ -8,6 +8,7 @@
  distribution_type: module
  requires:
    LWP::UserAgent: 0
+   HTTP::Request: 0
    perl: 5.005
  build_requires:
    Test: 0

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -5,7 +5,7 @@ use ExtUtils::MakeMaker;
 WriteMakefile(
     NAME              => 'SMS::AQL',
     VERSION_FROM      => 'lib/SMS/AQL.pm', # finds $VERSION
-    PREREQ_PM         => { LWP::UserAgent => 0 },
+    PREREQ_PM         => { LWP::UserAgent => 0, HTTP::Request => 0 },
     MIN_PERL_VERSION  => 5.005,
     ($] > 5.005 ?     ## Add these new keywords supported since 5.005
       (ABSTRACT_FROM  => 'lib/SMS/AQL.pm',


### PR DESCRIPTION
This used to be a part of libwww-perl, but was broken out into
HTTP::Message.

Since the module we're actually using is HTTP::Request, I specifically
added that one rather than the containing distribution.
